### PR TITLE
chore: scrub dev API key from n8n workflow and add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  secrets:
+    name: Secrets scan
+    uses: fwd-ford/.github/.github/workflows/secrets-scan.yml@main
+
+  docs:
+    name: Docs quality
+    uses: fwd-ford/.github/.github/workflows/docs-quality.yml@main

--- a/n8n-workflows/simple-leads-test.json
+++ b/n8n-workflows/simple-leads-test.json
@@ -22,7 +22,7 @@
         "sendHeaders": true,
         "headerParameters": {
           "parameters": [
-            { "name": "X-API-Key", "value": "forward-internal-dev-key-2026" }
+            { "name": "X-API-Key", "value": "REPLACE_WITH_API_KEY" }
           ]
         },
         "options": {}


### PR DESCRIPTION
## Summary

- `n8n-workflows/simple-leads-test.json`: replaced the hardcoded `forward-internal-dev-key-2026` value with `REPLACE_WITH_API_KEY` placeholder.
- `.github/workflows/ci.yml`: adds CI calling the org-shared `secrets-scan.yml` (gitleaks) and `docs-quality.yml`.

## Why

With the repo now public, the n8n workflow JSON was exposing the same dev API key that lived as a default in several other places. Production is on a rotated key (Fly secret); this PR removes the value from the public repo so future imports of this workflow require the operator to plug in the right key explicitly.

## Test plan

- [ ] CI runs and both `Secrets scan` and `Docs quality` pass
- [ ] Importing the workflow into n8n surfaces `REPLACE_WITH_API_KEY` as an obvious placeholder

## Related

- forward-infra#4 (mirror cleanup in docker-compose / .env.example)
- forward-api-java#11 (production key rotation — already done as Fly secret)