### PR TITLE
fix(ci): resolve unresolved merge conflict markers in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,15 +10,6 @@ permissions:
   contents: read
 
 jobs:
-<<<<<<< HEAD
-  secrets:
-    name: Secrets scan
-    uses: fwd-ford/.github/.github/workflows/secrets-scan.yml@main
-
-  docs:
-    name: Docs quality
-    uses: fwd-ford/.github/.github/workflows/docs-quality.yml@main
-=======
   docs:
     name: Docs quality
     uses: fwd-ford/.github/.github/workflows/docs-quality.yml@main
@@ -28,4 +19,3 @@ jobs:
     uses: fwd-ford/.github/.github/workflows/secrets-scan.yml@main
     with:
       scan-history: false
->>>>>>> 8bedbd1 (ci: add docs CI pipeline (markdownlint + lychee + gitleaks))


### PR DESCRIPTION
## Resumo

PR #12 (`ci: setup docs quality pipeline`) foi mergeada em 2026-05-20 com marcadores de merge nao resolvidos (`<<<<<<<`, `=======`, `>>>>>>>`) em `.github/workflows/ci.yml`.

Consequencia: YAML invalido bloqueou **TODA** execucao de CI no repo desde entao. Nem PR #14 (QA) nem PR #16 (cyber) disparam checks (`statusCheckRollup: []`).

## Resolucao

Preservei a versao trazida pela PR #12 (parametro `scan-history: false` no job de secrets, ordem docs/secrets), que era a intencao original da PR.

## Test plan

- [x] Diff mostra apenas remocao dos markers e da versao HEAD duplicada
- [x] yamllint clean apos fix (verificado local)
- [ ] CI executa apos merge (este eh o proprio fix — confirma post-merge)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>