### PR TITLE
docs(soa): pacote de entrega Sprint 1

### DIFF
--- a/academic/cyber/01_THREAT_MODEL.md
+++ b/academic/cyber/01_THREAT_MODEL.md
@@ -6,7 +6,7 @@
 
 > **Para quem é:** Prof. Vitor (Cybersecurity), avaliadores do Sprint 1, e qualquer pessoa que precise estender o sistema sem reabrir vulnerabilidades.
 >
-> **Escopo:** backend [forward-api-java](../../../forward-api-java/) (Spring Boot 3), banco [forward-infra](../../../forward-infra/) (Postgres + Supabase), app [forward-mobile](../../../forward-mobile/) (Expo). Excluído: serviço ML, web vazio, n8n.
+> **Escopo:** backend [forward-api-java](https://github.com/fwd-ford/forward-api-java) (Spring Boot 3), banco [forward-infra](https://github.com/fwd-ford/forward-infra) (Postgres + Supabase), app [forward-mobile](https://github.com/fwd-ford/forward-mobile) (Expo). Excluído: serviço ML, web vazio, n8n.
 
 ---
 
@@ -18,15 +18,15 @@ ForwardService manipula dados de cliente Ford (nome, CPF, e-mail, telefone, VIN)
 
 | Camada | Controle principal | Arquivo de referência |
 | --- | --- | --- |
-| Edge | TLS 1.2+ forçado via Fly.io | [fly.toml:18](../../../forward-api-java/fly.toml) |
-| Header | HSTS, CSP, X-Frame-Options DENY | [SecurityHeadersFilter.java](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/web/SecurityHeadersFilter.java) |
-| AuthN | JWT (HS256 ou JWKS) ou X-API-Key | [AuthFilter.java](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/security/AuthFilter.java) |
-| Integridade S2S | HMAC-SHA256 com timestamp | [HmacValidator.java](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/security/HmacValidator.java) |
-| AuthZ | RLS Postgres por role | [010_rls_policies.sql](../../../forward-infra/supabase/migrations/010_rls_policies.sql) |
-| Rate limit | Bucket4j por IP+sub | [RateLimitFilter.java](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/security/RateLimitFilter.java) |
-| Privacidade | Anonimização LGPD (reaper diário) | [013_lgpd_retention_policy.sql](../../../forward-infra/supabase/migrations/013_lgpd_retention_policy.sql) |
-| Auditoria | append-only audit_log | [009_create_audit_log.sql](../../../forward-infra/supabase/migrations/009_create_audit_log.sql) |
-| CI/CD | Trivy fs (CRITICAL/HIGH gate) + Dependabot | [java-security.yml](../../../.github/.github/workflows/java-security.yml) |
+| Edge | TLS 1.2+ forçado via Fly.io | [fly.toml:18](https://github.com/fwd-ford/forward-api-java/blob/main/fly.toml) |
+| Header | HSTS, CSP, X-Frame-Options DENY | [SecurityHeadersFilter.java](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/web/SecurityHeadersFilter.java) |
+| AuthN | JWT (HS256 ou JWKS) ou X-API-Key | [AuthFilter.java](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/security/AuthFilter.java) |
+| Integridade S2S | HMAC-SHA256 com timestamp | [HmacValidator.java](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/security/HmacValidator.java) |
+| AuthZ | RLS Postgres por role | [010_rls_policies.sql](https://github.com/fwd-ford/forward-infra/blob/main/supabase/migrations/010_rls_policies.sql) |
+| Rate limit | Bucket4j por IP+sub | [RateLimitFilter.java](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/security/RateLimitFilter.java) |
+| Privacidade | Anonimização LGPD (reaper diário) | [013_lgpd_retention_policy.sql](https://github.com/fwd-ford/forward-infra/blob/main/supabase/migrations/013_lgpd_retention_policy.sql) |
+| Auditoria | append-only audit_log | [009_create_audit_log.sql](https://github.com/fwd-ford/forward-infra/blob/main/supabase/migrations/009_create_audit_log.sql) |
+| CI/CD | Trivy fs (CRITICAL/HIGH gate) + Dependabot | [java-security.yml](https://github.com/fwd-ford/.github/blob/main/.github/workflows/java-security.yml) |
 
 ---
 
@@ -87,7 +87,7 @@ flowchart LR
 
 **Pontos de entrada autenticados:**
 
-- REST `/api/v1/*` (controllers em [web/](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/web/))
+- REST `/api/v1/*` (controllers em [web/](https://github.com/fwd-ford/forward-api-java/tree/main/src/main/java/com/fwdford/forwardapi/web))
 - SOAP `/soap/vehicles` (operação GetVehicle)
 
 **Pontos públicos por design:**
@@ -105,61 +105,61 @@ flowchart LR
 
 | Ameaça | Cenário | Mitigação | Status |
 | --- | --- | --- | --- |
-| **S** Spoofing | Cliente falsifica origem (host header injection, IP spoof) | Fly.io edge valida TLS handshake; backend lê `X-Forwarded-For` apenas para log, decisões usam `request.getRemoteAddr()` em [RateLimitFilter.java:72](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/security/RateLimitFilter.java) | ✅ |
-| **T** Tampering | MITM em trânsito | `force_https = true` em [fly.toml:18](../../../forward-api-java/fly.toml); HSTS `max-age=31536000` em [SecurityHeadersFilter.java:26](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/web/SecurityHeadersFilter.java) | ✅ |
+| **S** Spoofing | Cliente falsifica origem (host header injection, IP spoof) | Fly.io edge valida TLS handshake; backend lê `X-Forwarded-For` apenas para log, decisões usam `request.getRemoteAddr()` em [RateLimitFilter.java:72](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/security/RateLimitFilter.java) | ✅ |
+| **T** Tampering | MITM em trânsito | `force_https = true` em [fly.toml:18](https://github.com/fwd-ford/forward-api-java/blob/main/fly.toml); HSTS `max-age=31536000` em [SecurityHeadersFilter.java:26](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/web/SecurityHeadersFilter.java) | ✅ |
 | **R** Repudiation | Cliente nega ação que fez | Body raw + `X-Request-Id` em audit_log; ver §4.6 | ✅ |
-| **I** Information disclosure | Stack trace ou banner do Tomcat vaza tecnologia | [GlobalExceptionHandler.java:67-69](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/error/GlobalExceptionHandler.java) retorna mensagem genérica em pt-BR; Tomcat `server-header` removido implicitamente pelo Spring Boot default | ✅ |
-| **D** Denial of service | Flood de requests | Bucket4j 60 req/min por IP+sub ([RateLimitFilter.java:62-68](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/security/RateLimitFilter.java)); Tomcat body limit 1MB ([application.yml:7-8](../../../forward-api-java/src/main/resources/application.yml)) | ✅ |
+| **I** Information disclosure | Stack trace ou banner do Tomcat vaza tecnologia | [GlobalExceptionHandler.java:67-69](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/error/GlobalExceptionHandler.java) retorna mensagem genérica em pt-BR; Tomcat `server-header` removido implicitamente pelo Spring Boot default | ✅ |
+| **D** Denial of service | Flood de requests | Bucket4j 60 req/min por IP+sub ([RateLimitFilter.java:62-68](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/security/RateLimitFilter.java)); Tomcat body limit 1MB ([application.yml:7-8](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/resources/application.yml)) | ✅ |
 | **E** Elevation of privilege | Acesso sem TLS expondo token em texto claro | HSTS força HTTPS no browser por 1 ano | ✅ |
 
 ### 4.2 AuthFilter (validação de token)
 
 | Ameaça | Cenário | Mitigação | Status |
 | --- | --- | --- | --- |
-| **S** | Token forjado | JWT validado com chave Supabase (HS256) ou JWKS asymmetric; `AlgAwareJwtValidator` roteia pelo header `alg` ([JwtValidatorFactory.java:30](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/security/JwtValidatorFactory.java)) | ✅ |
-| **S** | Reuso de X-API-Key vazada | Reduzido por HMAC opcional ([HmacValidator.java](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/security/HmacValidator.java)); fora isso, rotação manual | ⚠️ (rotação manual) |
+| **S** | Token forjado | JWT validado com chave Supabase (HS256) ou JWKS asymmetric; `AlgAwareJwtValidator` roteia pelo header `alg` ([JwtValidatorFactory.java:30](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/security/JwtValidatorFactory.java)) | ✅ |
+| **S** | Reuso de X-API-Key vazada | Reduzido por HMAC opcional ([HmacValidator.java](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/security/HmacValidator.java)); fora isso, rotação manual | ⚠️ (rotação manual) |
 | **T** | Token modificado em trânsito | Assinatura JWT invalidaria; HTTPS impede inspeção | ✅ |
 | **R** | Usuário nega que chamou endpoint | `sub` do JWT vai pro audit_log; `X-Request-Id` correlaciona logs JSON | ✅ |
-| **I** | Token vaza em log | `Authorization` header nunca é logado; MDC carrega só `request_id` ([RequestIdFilter.java:33](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/web/RequestIdFilter.java)) | ✅ |
+| **I** | Token vaza em log | `Authorization` header nunca é logado; MDC carrega só `request_id` ([RequestIdFilter.java:33](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/web/RequestIdFilter.java)) | ✅ |
 | **D** | Brute force em senha | Login fica no Supabase Auth (não na nossa API); rate limit Bucket4j cobre tentativas no nosso lado | ✅ |
-| **E** | Forjar role no JWT | Role vem do claim `role` ou `app_metadata.role` validado pela assinatura ([AuthFilter.java:103-110](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/security/AuthFilter.java)); RLS no Postgres é a segunda barreira | ✅ |
+| **E** | Forjar role no JWT | Role vem do claim `role` ou `app_metadata.role` validado pela assinatura ([AuthFilter.java:103-110](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/security/AuthFilter.java)); RLS no Postgres é a segunda barreira | ✅ |
 
 ### 4.3 Camada de serviço (RBAC + business logic)
 
 | Ameaça | Cenário | Mitigação | Status |
 | --- | --- | --- | --- |
 | **S** | Service chama outro service como usuário diferente | `AuthPrincipal` é imutável e atravessa a stack por request attribute, não thread-local global | ✅ |
-| **T** | Injection via parâmetro de query | Tudo via `NamedParameterJdbcTemplate` com `:bind` (ver [repository/](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/repository/)); zero concatenação de SQL | ✅ |
-| **R** | Ação destrutiva sem trilha | INSERTs em audit_log via service quando ação for sensível (anonimização em [013_lgpd_retention_policy.sql:46](../../../forward-infra/supabase/migrations/013_lgpd_retention_policy.sql)); cobertura para CRUD comum é P1 (ver seção 6) | ⚠️ (cobertura parcial) |
-| **I** | Endpoint vaza customer de outro dealer | Defense-in-depth: validação no service + RLS no Postgres com `auth_role()` ([010_rls_policies.sql:29-50](../../../forward-infra/supabase/migrations/010_rls_policies.sql)) | ✅ |
-| **D** | Query custosa (full table scan) | Limites bounded em `Validations.validateLimit` ([Validations.java:40-66](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/web/Validations.java)); índices em audit_log e leads | ✅ |
-| **E** | Cliente acessa churn_score (interno) | RLS `churn_scores_internal` restringe a `analyst`/`admin` ([010_rls_policies.sql:44](../../../forward-infra/supabase/migrations/010_rls_policies.sql)) | ✅ |
+| **T** | Injection via parâmetro de query | Tudo via `NamedParameterJdbcTemplate` com `:bind` (ver [repository/](https://github.com/fwd-ford/forward-api-java/tree/main/src/main/java/com/fwdford/forwardapi/repository)); zero concatenação de SQL | ✅ |
+| **R** | Ação destrutiva sem trilha | INSERTs em audit_log via service quando ação for sensível (anonimização em [013_lgpd_retention_policy.sql:46](https://github.com/fwd-ford/forward-infra/blob/main/supabase/migrations/013_lgpd_retention_policy.sql)); cobertura para CRUD comum é P1 (ver seção 6) | ⚠️ (cobertura parcial) |
+| **I** | Endpoint vaza customer de outro dealer | Defense-in-depth: validação no service + RLS no Postgres com `auth_role()` ([010_rls_policies.sql:29-50](https://github.com/fwd-ford/forward-infra/blob/main/supabase/migrations/010_rls_policies.sql)) | ✅ |
+| **D** | Query custosa (full table scan) | Limites bounded em `Validations.validateLimit` ([Validations.java:40-66](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/web/Validations.java)); índices em audit_log e leads | ✅ |
+| **E** | Cliente acessa churn_score (interno) | RLS `churn_scores_internal` restringe a `analyst`/`admin` ([010_rls_policies.sql:44](https://github.com/fwd-ford/forward-infra/blob/main/supabase/migrations/010_rls_policies.sql)) | ✅ |
 
 ### 4.4 Validação de entrada
 
 | Vetor | Mitigação | Arquivo |
 | --- | --- | --- |
-| UUID malformado | Regex RFC 4122 | [Validations.java:11-26](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/web/Validations.java) |
-| VIN inválido | Regex ISO 3779 (17 chars, sem I/O/Q) | [Validations.java:14, 30-36](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/web/Validations.java) |
-| Enum fora do whitelist | `validateEnum` com lista fixa | [Validations.java:70-78](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/web/Validations.java) |
-| Limit overflow | Clamp `[1, max]` | [Validations.java:40-66](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/web/Validations.java) |
-| Body gigante | Tomcat `max-http-form-post-size: 1MB`, env `MAX_BODY_BYTES` | [application.yml:7-8](../../../forward-api-java/src/main/resources/application.yml) |
-| JSON malformado | `HttpMessageNotReadableException` mapeado para 400 RFC 7807 | [GlobalExceptionHandler.java:52-61](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/error/GlobalExceptionHandler.java) |
-| Bean Validation failure | `MethodArgumentNotValidException` mapeado, mensagem agregada por campo | [GlobalExceptionHandler.java:34-50](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/error/GlobalExceptionHandler.java) |
+| UUID malformado | Regex RFC 4122 | [Validations.java:11-26](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/web/Validations.java) |
+| VIN inválido | Regex ISO 3779 (17 chars, sem I/O/Q) | [Validations.java:14, 30-36](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/web/Validations.java) |
+| Enum fora do whitelist | `validateEnum` com lista fixa | [Validations.java:70-78](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/web/Validations.java) |
+| Limit overflow | Clamp `[1, max]` | [Validations.java:40-66](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/web/Validations.java) |
+| Body gigante | Tomcat `max-http-form-post-size: 1MB`, env `MAX_BODY_BYTES` | [application.yml:7-8](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/resources/application.yml) |
+| JSON malformado | `HttpMessageNotReadableException` mapeado para 400 RFC 7807 | [GlobalExceptionHandler.java:52-61](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/error/GlobalExceptionHandler.java) |
+| Bean Validation failure | `MethodArgumentNotValidException` mapeado, mensagem agregada por campo | [GlobalExceptionHandler.java:34-50](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/error/GlobalExceptionHandler.java) |
 
 ### 4.5 CORS e cabeçalhos
 
 | Cabeçalho | Valor | Por que |
 | --- | --- | --- |
-| `Access-Control-Allow-Origin` | Allowlist explícita de `ALLOWED_ORIGINS` em [fly.toml:11](../../../forward-api-java/fly.toml) | Nunca `*`; expo.dev, expo.io, localhost dev. Validado em [CorsConfig.java:26](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/web/CorsConfig.java) |
+| `Access-Control-Allow-Origin` | Allowlist explícita de `ALLOWED_ORIGINS` em [fly.toml:11](https://github.com/fwd-ford/forward-api-java/blob/main/fly.toml) | Nunca `*`; expo.dev, expo.io, localhost dev. Validado em [CorsConfig.java:26](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/web/CorsConfig.java) |
 | `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` | HSTS preload-ready, evita downgrade |
 | `X-Frame-Options` | `DENY` | Anti-clickjacking |
 | `X-Content-Type-Options` | `nosniff` | Anti-MIME-sniffing |
-| `Content-Security-Policy` | `default-src 'none'; frame-ancestors 'none'` (default), `'self'` + `'unsafe-inline'` para `/swagger-ui` apenas | Lockdown total fora do Swagger ([SecurityHeadersFilter.java:35-46](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/web/SecurityHeadersFilter.java)) |
+| `Content-Security-Policy` | `default-src 'none'; frame-ancestors 'none'` (default), `'self'` + `'unsafe-inline'` para `/swagger-ui` apenas | Lockdown total fora do Swagger ([SecurityHeadersFilter.java:35-46](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/web/SecurityHeadersFilter.java)) |
 | `Referrer-Policy` | `no-referrer` | Evita leak de URL em outbound |
 | `Permissions-Policy` | `geolocation=()`, `microphone=()`, `camera=()` | Negação de APIs sensíveis |
 
-CORS subiu antes da auth no chain ([SecurityConfig.java:27, 34](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/security/SecurityConfig.java)) para garantir que 401 ainda carregue `Access-Control-Allow-Origin` (sem isso o browser bloqueava como erro CORS antes do dev ver o 401 real).
+CORS subiu antes da auth no chain ([SecurityConfig.java:27, 34](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/security/SecurityConfig.java)) para garantir que 401 ainda carregue `Access-Control-Allow-Origin` (sem isso o browser bloqueava como erro CORS antes do dev ver o 401 real).
 
 ### 4.6 Auditoria e logs
 
@@ -167,8 +167,8 @@ CORS subiu antes da auth no chain ([SecurityConfig.java:27, 34](../../../forward
 | --- | --- |
 | `RequestIdFilter` | Gera `X-Request-Id` (UUID) ou aceita o do cliente; injeta no MDC do SLF4J |
 | `logback-spring.xml` | JSON estruturado em prod via Logstash encoder; `service: forward-api` como custom field |
-| `audit_log` | Tabela append-only ([009_create_audit_log.sql](../../../forward-infra/supabase/migrations/009_create_audit_log.sql)); `REVOKE UPDATE, DELETE ON audit_log FROM PUBLIC`. Campos: `actor_id`, `actor_role`, `action`, `resource_type`, `resource_id`, `ip_address`, `user_agent`, `request_id`, `payload` JSONB |
-| Erros não tratados | Logados via `log.error(...)` com stack interno; **resposta** ao cliente é genérica ([GlobalExceptionHandler.java:66-69](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/error/GlobalExceptionHandler.java)) |
+| `audit_log` | Tabela append-only ([009_create_audit_log.sql](https://github.com/fwd-ford/forward-infra/blob/main/supabase/migrations/009_create_audit_log.sql)); `REVOKE UPDATE, DELETE ON audit_log FROM PUBLIC`. Campos: `actor_id`, `actor_role`, `action`, `resource_type`, `resource_id`, `ip_address`, `user_agent`, `request_id`, `payload` JSONB |
+| Erros não tratados | Logados via `log.error(...)` com stack interno; **resposta** ao cliente é genérica ([GlobalExceptionHandler.java:66-69](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/error/GlobalExceptionHandler.java)) |
 
 ### 4.7 Dados em repouso e privacidade (LGPD)
 
@@ -176,16 +176,16 @@ CORS subiu antes da auth no chain ([SecurityConfig.java:27, 34](../../../forward
 | --- | --- |
 | VIN | Pseudonimizado pela Ford com SHA1 (testado: 5M tentativas de reversão = 0 matches, conforme [02e Parte 5](../../project/02e_DATASET_OFICIAL_E_FONTES.md)) |
 | PII em DB | Cifrado em repouso pelo Supabase (AES-256 no storage layer). Sem cifragem adicional aplicação (decisão Sprint 1; ver seção 6) |
-| Direito ao esquecimento | `anonymize_customer(uuid)` ([013_lgpd_retention_policy.sql:21-57](../../../forward-infra/supabase/migrations/013_lgpd_retention_policy.sql)); preserva FK setando PII para NULL ou `[ANONYMIZED]` |
-| Retenção | `anonymize_expired_customers()` reaper diário ([013_lgpd_retention_policy.sql:66-93](../../../forward-infra/supabase/migrations/013_lgpd_retention_policy.sql)); critério: deletion request com cooling-off de 30d, OU sem consentimento LGPD com idade > 12m |
+| Direito ao esquecimento | `anonymize_customer(uuid)` ([013_lgpd_retention_policy.sql:21-57](https://github.com/fwd-ford/forward-infra/blob/main/supabase/migrations/013_lgpd_retention_policy.sql)); preserva FK setando PII para NULL ou `[ANONYMIZED]` |
+| Retenção | `anonymize_expired_customers()` reaper diário ([013_lgpd_retention_policy.sql:66-93](https://github.com/fwd-ford/forward-infra/blob/main/supabase/migrations/013_lgpd_retention_policy.sql)); critério: deletion request com cooling-off de 30d, OU sem consentimento LGPD com idade > 12m |
 | Não-repúdio | Cada anonimização emite linha em audit_log com `reason` e `at` |
-| Anonimização para ML | VIN_Hash já é seguro; pipeline ML em [forward-ml/](../../../forward-ml/) consome somente o feature store derivado, sem PII direta |
+| Anonimização para ML | VIN_Hash já é seguro; pipeline ML em [forward-ml/](https://github.com/fwd-ford/forward-ml) consome somente o feature store derivado, sem PII direta |
 
 ### 4.8 Pipeline CI/CD
 
 | Risco | Mitigação |
 | --- | --- |
-| Dependência com CVE | **Trivy filesystem scan** em CI com gate em CRITICAL/HIGH ([java-security.yml:11-23](../../../.github/.github/workflows/java-security.yml)); **Dependabot** abre PRs automáticas para atualizações |
+| Dependência com CVE | **Trivy filesystem scan** em CI com gate em CRITICAL/HIGH ([java-security.yml:11-23](https://github.com/fwd-ford/.github/blob/main/.github/workflows/java-security.yml)); **Dependabot** abre PRs automáticas para atualizações |
 | Segredo commitado | `secrets-scan.yml` (gitleaks) bloqueia push com segredo identificado |
 | Build supply chain | Maven wrapper pinado, `actions/checkout@v4` e `actions/setup-java@v4` em versões fixas |
 

--- a/academic/cyber/02_OWASP_TOP10.md
+++ b/academic/cyber/02_OWASP_TOP10.md
@@ -8,7 +8,7 @@
 >
 > **Objetivo:** demonstrar que cada categoria do OWASP Top 10 2021 foi analisada contra o código do ForwardService, com mitigação implementada ou risco aceito justificado.
 >
-> **Escopo de análise:** backend [forward-api-java](../../../forward-api-java/), camada de dados [forward-infra](../../../forward-infra/), app [forward-mobile](../../../forward-mobile/).
+> **Escopo de análise:** backend [forward-api-java](https://github.com/fwd-ford/forward-api-java), camada de dados [forward-infra](https://github.com/fwd-ford/forward-infra), app [forward-mobile](https://github.com/fwd-ford/forward-mobile).
 >
 > **Importante:** Este documento usa o **framework conceitual OWASP Top 10 2021** (lista de categorias de vulnerabilidade). Não há mais ferramenta automática **OWASP Dependency-Check** no CI: ela foi removida em 2026-05-23 (PR #17), substituída por **Trivy filesystem scan** (gate CRITICAL/HIGH) + **Dependabot**. Detalhes da remoção e justificativa estão na seção A06 deste documento.
 
@@ -43,14 +43,14 @@
 
 **Mitigações implementadas:**
 
-1. **AuthN obrigatória em qualquer `/api/v1/*`:** [SecurityConfig.java:36-47](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/security/SecurityConfig.java) só libera `/health`, `/ready`, `/actuator/**`, `/swagger-ui/**`, `/v3/api-docs/**`, `/soap/vehicles.wsdl` e OPTIONS. Todo o resto passa por [AuthFilter](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/security/AuthFilter.java).
+1. **AuthN obrigatória em qualquer `/api/v1/*`:** [SecurityConfig.java:36-47](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/security/SecurityConfig.java) só libera `/health`, `/ready`, `/actuator/**`, `/swagger-ui/**`, `/v3/api-docs/**`, `/soap/vehicles.wsdl` e OPTIONS. Todo o resto passa por [AuthFilter](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/security/AuthFilter.java).
 2. **`AuthPrincipal` imutável por request:** o `sub` e `role` extraídos do JWT são salvos em request attribute (`WebAttrs.PRINCIPAL`), nunca em ThreadLocal global. Services consultam pelo objeto.
 3. **RBAC verificado no service:** services validam `callerSub`/`callerRole` antes de retornar dados. Exemplo: `CustomerService.get()`.
-4. **Defense-in-depth com RLS:** mesmo se o service falhar, [010_rls_policies.sql](../../../forward-infra/supabase/migrations/010_rls_policies.sql) bloqueia no banco. Exemplos:
+4. **Defense-in-depth com RLS:** mesmo se o service falhar, [010_rls_policies.sql](https://github.com/fwd-ford/forward-infra/blob/main/supabase/migrations/010_rls_policies.sql) bloqueia no banco. Exemplos:
    - `churn_scores_internal`: leitura só para `analyst`/`admin`.
    - `customers_self`: cliente só vê o próprio registro; dealer/analyst/admin veem mais.
    - `audit_log_admin_only`: trilha de auditoria só admin lê.
-5. **Role nunca confiada do cliente:** o claim `role` vem do JWT assinado pelo Supabase ([AuthFilter.java:103-110](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/security/AuthFilter.java)). Adulteração quebra a assinatura.
+5. **Role nunca confiada do cliente:** o claim `role` vem do JWT assinado pelo Supabase ([AuthFilter.java:103-110](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/security/AuthFilter.java)). Adulteração quebra a assinatura.
 
 **Status:** ✅ Mitigado.
 
@@ -72,13 +72,13 @@
 
 | Item | Implementação |
 | --- | --- |
-| TLS em trânsito | `force_https = true` em [fly.toml:18](../../../forward-api-java/fly.toml); TLS 1.2+ pelo edge Fly.io |
-| HSTS | `Strict-Transport-Security: max-age=31536000; includeSubDomains` em [SecurityHeadersFilter.java:26](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/web/SecurityHeadersFilter.java) |
+| TLS em trânsito | `force_https = true` em [fly.toml:18](https://github.com/fwd-ford/forward-api-java/blob/main/fly.toml); TLS 1.2+ pelo edge Fly.io |
+| HSTS | `Strict-Transport-Security: max-age=31536000; includeSubDomains` em [SecurityHeadersFilter.java:26](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/web/SecurityHeadersFilter.java) |
 | Cifragem em repouso | Supabase Postgres cifra storage com AES-256 nativamente |
-| JWT | HS256 (HMAC-SHA256) via Nimbus JOSE ou JWKS RSA via JJWT. Algoritmo escolhido pelo header do token ([AlgAwareJwtValidator](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/security/AlgAwareJwtValidator.java)) |
-| HMAC integridade body | `HMAC_SHA256(secret, "<ts>:<METHOD>:<path>:<sha256(body)>")` em [HmacValidator.java:84-95](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/security/HmacValidator.java) |
-| Comparação constant-time | `constantTimeEquals` evita timing oracle em [HmacValidator.java:115-124](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/security/HmacValidator.java) |
-| Replay protection | `X-Timestamp` com janela de skew de 5 min ([HmacValidator.java:25, 74](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/security/HmacValidator.java)) |
+| JWT | HS256 (HMAC-SHA256) via Nimbus JOSE ou JWKS RSA via JJWT. Algoritmo escolhido pelo header do token ([AlgAwareJwtValidator](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/security/AlgAwareJwtValidator.java)) |
+| HMAC integridade body | `HMAC_SHA256(secret, "<ts>:<METHOD>:<path>:<sha256(body)>")` em [HmacValidator.java:84-95](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/security/HmacValidator.java) |
+| Comparação constant-time | `constantTimeEquals` evita timing oracle em [HmacValidator.java:115-124](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/security/HmacValidator.java) |
+| Replay protection | `X-Timestamp` com janela de skew de 5 min ([HmacValidator.java:25, 74](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/security/HmacValidator.java)) |
 | Segredos | `SUPABASE_JWT_SECRET`, `DATABASE_PASSWORD`, `INTERNAL_API_KEY` via env var Fly.io secrets (cifradas at rest no Fly) |
 | VIN do cliente | Pré-pseudonimizado pela Ford com SHA1 (5M tentativas de reversão = 0 matches, ver [02e Parte 5](../../project/02e_DATASET_OFICIAL_E_FONTES.md)) |
 
@@ -102,25 +102,25 @@
 
 ### SQL Injection
 - **100% das queries parametrizadas:** repositórios usam `NamedParameterJdbcTemplate` com `:nomeDoBind`. Exemplo: `LeadRepository.java`.
-- **Zero concatenação de SQL:** convenção do repo confirmada em [forward-api-java/CLAUDE.md](../../../forward-api-java/CLAUDE.md) ("All queries parameterized, never concatenated").
-- **Validação prévia:** UUIDs, VINs e enums validados antes de chegar ao repository ([Validations.java](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/web/Validations.java)).
+- **Zero concatenação de SQL:** convenção do repo confirmada em [forward-api-java/CLAUDE.md](https://github.com/fwd-ford/forward-api-java/blob/main/CLAUDE.md) ("All queries parameterized, never concatenated").
+- **Validação prévia:** UUIDs, VINs e enums validados antes de chegar ao repository ([Validations.java](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/web/Validations.java)).
 
 ### XSS
 - **API JSON, sem template server-side:** o backend não renderiza HTML. Cabeçalho `Content-Type: application/json` impede execução em browser direto.
-- **`X-Content-Type-Options: nosniff`** e **`X-Frame-Options: DENY`** ([SecurityHeadersFilter.java:23-24](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/web/SecurityHeadersFilter.java)) impedem MIME-sniffing e clickjacking.
-- **CSP `default-src 'none'`** fora do Swagger ([SecurityHeadersFilter.java:45](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/web/SecurityHeadersFilter.java)).
+- **`X-Content-Type-Options: nosniff`** e **`X-Frame-Options: DENY`** ([SecurityHeadersFilter.java:23-24](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/web/SecurityHeadersFilter.java)) impedem MIME-sniffing e clickjacking.
+- **CSP `default-src 'none'`** fora do Swagger ([SecurityHeadersFilter.java:45](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/web/SecurityHeadersFilter.java)).
 - **Mobile (Expo):** React Native escapa strings interpoladas por padrão; APIs de injeção direta de HTML não existem no runtime de RN.
 
 ### Command Injection
 - **Sem `Runtime.exec`, `ProcessBuilder` ou integração shell** no código. Confirmado por grep no repo.
 
 ### Header Injection
-- `X-Request-Id` aceito do cliente é tratado como string opaca em MDC ([RequestIdFilter.java:27-29](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/web/RequestIdFilter.java)).
+- `X-Request-Id` aceito do cliente é tratado como string opaca em MDC ([RequestIdFilter.java:27-29](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/web/RequestIdFilter.java)).
 - `X-Forwarded-For` não é usado para decisões de segurança (rate limit usa `request.getRemoteAddr()`).
 
 ### XML/XXE (SOAP)
-- Spring WS desabilita external entities por padrão em [VehicleEndpoint](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/soap/).
-- Schema XSD em [vehicles.xsd](../../../forward-api-java/src/main/resources/xsd/vehicles.xsd) define contrato; entidades externas são rejeitadas.
+- Spring WS desabilita external entities por padrão em [VehicleEndpoint](https://github.com/fwd-ford/forward-api-java/tree/main/src/main/java/com/fwdford/forwardapi/soap).
+- Schema XSD em [vehicles.xsd](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/resources/xsd/vehicles.xsd) define contrato; entidades externas são rejeitadas.
 
 **Status:** ✅ Mitigado.
 
@@ -137,9 +137,9 @@
 3. **Princípio do menor privilégio:**
    - Roles distintas: `user`, `dealer`, `analyst`, `admin`.
    - `churn_score` invisível para `user`.
-   - `audit_log` apenas leitura admin; `REVOKE UPDATE, DELETE ON audit_log FROM PUBLIC` ([009_create_audit_log.sql:26](../../../forward-infra/supabase/migrations/009_create_audit_log.sql)).
+   - `audit_log` apenas leitura admin; `REVOKE UPDATE, DELETE ON audit_log FROM PUBLIC` ([009_create_audit_log.sql:26](https://github.com/fwd-ford/forward-infra/blob/main/supabase/migrations/009_create_audit_log.sql)).
 4. **Portão único:** SOA com backend como único ponto de entrada (ver [03_SOLUTION_DESIGN.md §150-191](../../project/03_SOLUTION_DESIGN.md)). Mobile, web e N8N não falam direto com banco.
-5. **Stateless por design:** `SessionCreationPolicy.STATELESS` ([SecurityConfig.java:35](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/security/SecurityConfig.java)), evitando session fixation e CSRF.
+5. **Stateless por design:** `SessionCreationPolicy.STATELESS` ([SecurityConfig.java:35](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/security/SecurityConfig.java)), evitando session fixation e CSRF.
 6. **Fail-secure:** sem credencial → 401, sem rate limit budget → 429, sem permissão → 403 (sempre RFC 7807, sem stack trace).
 
 **Status:** ✅ Mitigado.
@@ -154,16 +154,16 @@
 
 | Misconfiguration | Mitigação | Arquivo |
 | --- | --- | --- |
-| CORS wildcard | Allowlist explícita; rejeita `*`. | [CorsConfig.java:26](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/web/CorsConfig.java) + [fly.toml:11](../../../forward-api-java/fly.toml) |
-| Session habilitada (CSRF) | STATELESS, CSRF desabilitado | [SecurityConfig.java:28, 35](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/security/SecurityConfig.java) |
-| Form login default | Desabilitado | [SecurityConfig.java:29](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/security/SecurityConfig.java) |
-| HTTP Basic default | Desabilitado | [SecurityConfig.java:30](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/security/SecurityConfig.java) |
-| Actuator exposto | Só `health` e `info` expostos; `show-details: never` em health | [application.yml:26-34](../../../forward-api-java/src/main/resources/application.yml) |
-| Stack trace em response | Generic message + RFC 7807; stack apenas em log interno | [GlobalExceptionHandler.java:66-69](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/error/GlobalExceptionHandler.java) |
-| Log spam Spring Security | `org.springframework.security: WARN` | [application.yml:39](../../../forward-api-java/src/main/resources/application.yml) |
-| CSP padrão aberto | `default-src 'none'; frame-ancestors 'none'` (lockdown) fora do Swagger | [SecurityHeadersFilter.java:45](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/web/SecurityHeadersFilter.java) |
-| HTTP em produção | `force_https = true` no edge | [fly.toml:18](../../../forward-api-java/fly.toml) |
-| Body upload ilimitado | `max-http-form-post-size: 1MB`, env `MAX_BODY_BYTES` | [application.yml:7-8](../../../forward-api-java/src/main/resources/application.yml) |
+| CORS wildcard | Allowlist explícita; rejeita `*`. | [CorsConfig.java:26](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/web/CorsConfig.java) + [fly.toml:11](https://github.com/fwd-ford/forward-api-java/blob/main/fly.toml) |
+| Session habilitada (CSRF) | STATELESS, CSRF desabilitado | [SecurityConfig.java:28, 35](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/security/SecurityConfig.java) |
+| Form login default | Desabilitado | [SecurityConfig.java:29](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/security/SecurityConfig.java) |
+| HTTP Basic default | Desabilitado | [SecurityConfig.java:30](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/security/SecurityConfig.java) |
+| Actuator exposto | Só `health` e `info` expostos; `show-details: never` em health | [application.yml:26-34](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/resources/application.yml) |
+| Stack trace em response | Generic message + RFC 7807; stack apenas em log interno | [GlobalExceptionHandler.java:66-69](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/error/GlobalExceptionHandler.java) |
+| Log spam Spring Security | `org.springframework.security: WARN` | [application.yml:39](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/resources/application.yml) |
+| CSP padrão aberto | `default-src 'none'; frame-ancestors 'none'` (lockdown) fora do Swagger | [SecurityHeadersFilter.java:45](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/web/SecurityHeadersFilter.java) |
+| HTTP em produção | `force_https = true` no edge | [fly.toml:18](https://github.com/fwd-ford/forward-api-java/blob/main/fly.toml) |
+| Body upload ilimitado | `max-http-form-post-size: 1MB`, env `MAX_BODY_BYTES` | [application.yml:7-8](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/resources/application.yml) |
 | Banner do Tomcat | Spring Boot remove `Server` header por padrão; não foi reativado | n/a |
 
 **Status:** ✅ Mitigado.
@@ -187,12 +187,12 @@ Em 2026-05-23 o profile Maven `security` (que rodava `dependency-check-maven 10.
 
 | Ferramenta | Função | Onde |
 | --- | --- | --- |
-| **Trivy filesystem scan** | Gate de CI em CRITICAL/HIGH, `exit-code: 1`, `ignore-unfixed: true` | [java-security.yml:11-23](../../../.github/.github/workflows/java-security.yml) |
+| **Trivy filesystem scan** | Gate de CI em CRITICAL/HIGH, `exit-code: 1`, `ignore-unfixed: true` | [java-security.yml:11-23](https://github.com/fwd-ford/.github/blob/main/.github/workflows/java-security.yml) |
 | **Dependabot** | PRs automáticas para atualizações | configurado por repo |
-| **SpotBugs + FindSecBugs** | SAST estático no profile `quality` | [pom.xml](../../../forward-api-java/pom.xml) |
+| **SpotBugs + FindSecBugs** | SAST estático no profile `quality` | [pom.xml](https://github.com/fwd-ford/forward-api-java/blob/main/pom.xml) |
 | **gitleaks** | Scan de segredos no diff | `secrets-scan.yml` |
 
-**Pendência:** o job `dependency-check` no workflow compartilhado [java-security.yml:26-46](../../../.github/.github/workflows/java-security.yml) ainda existe mas roda `./mvnw verify -P security` que **falha silenciosamente** (`continue-on-error: true`) porque o profile não existe mais no pom. PR [`.github#3`](https://github.com/fwd-ford/.github/pull/3) (chore/drop-owasp-dependency-check) está OPEN para remover o job — sem impacto de segurança porque já não era gate.
+**Pendência:** o job `dependency-check` no workflow compartilhado [java-security.yml:26-46](https://github.com/fwd-ford/.github/blob/main/.github/workflows/java-security.yml) ainda existe mas roda `./mvnw verify -P security` que **falha silenciosamente** (`continue-on-error: true`) porque o profile não existe mais no pom. PR [`.github#3`](https://github.com/fwd-ford/.github/pull/3) (chore/drop-owasp-dependency-check) está OPEN para remover o job — sem impacto de segurança porque já não era gate.
 
 **Por que não voltar OWASP DC depois:** Trivy filesystem cobre o mesmo terreno sem as duas patologias acima. Se um dia o projeto precisar de SCA mais robusto, considerar `trivy fs --scanners vuln,license` ou Snyk OSS — nunca OWASP DC.
 
@@ -209,10 +209,10 @@ Em 2026-05-23 o profile Maven `security` (que rodava `dependency-check-maven 10.
 1. **AuthN delegada para Supabase Auth:** o forward-api-java **não emite tokens** — valida tokens emitidos pelo Supabase. Isso significa:
    - Hash de senha, MFA, password reset, account lockout = responsabilidade do Supabase Auth (PBKDF2, bcrypt).
    - Brute force de login fica do lado do Supabase; rate limit Bucket4j no nosso lado complementa.
-2. **JWT validation rigorosa:** [AuthFilter.java:84-101](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/security/AuthFilter.java) rejeita `null`, header sem `Bearer `, e exceções do validator viram 401 genérico (não vaza motivo).
+2. **JWT validation rigorosa:** [AuthFilter.java:84-101](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/security/AuthFilter.java) rejeita `null`, header sem `Bearer `, e exceções do validator viram 401 genérico (não vaza motivo).
 3. **Algoritmo do token validado:** `AlgAwareJwtValidator` roteia pelo header `alg`, não permite `none` algorithm attack (Nimbus JOSE e JJWT já rejeitam).
 4. **Stateless:** sem session = sem session fixation.
-5. **X-API-Key constant-time?** Não — comparação `String.equals` em [AuthFilter.java:78](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/security/AuthFilter.java). Risco baixo porque a key é longa e não há contexto onde timing seja explorável remotamente em volume; mas é candidato a refactor para `MessageDigest.isEqual` no Sprint 2 (tracking em [03_SECURITY_PLAN.md §3.R6](./03_SECURITY_PLAN.md)).
+5. **X-API-Key constant-time?** Não — comparação `String.equals` em [AuthFilter.java:78](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/security/AuthFilter.java). Risco baixo porque a key é longa e não há contexto onde timing seja explorável remotamente em volume; mas é candidato a refactor para `MessageDigest.isEqual` no Sprint 2 (tracking em [03_SECURITY_PLAN.md §3.R6](./03_SECURITY_PLAN.md)).
 6. **Token nunca logado:** `Authorization` header não vai pro MDC ou pro JSON log.
 
 **Status:** ✅ Mitigado.
@@ -225,13 +225,13 @@ Em 2026-05-23 o profile Maven `security` (que rodava `dependency-check-maven 10.
 
 **Mitigações implementadas:**
 
-1. **HMAC opcional para chamadas server-to-server:** [HmacValidator.java](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/security/HmacValidator.java) implementa `HMAC_SHA256(secret, "<timestamp>:<METHOD>:<path>:<sha256(body)>")` com:
+1. **HMAC opcional para chamadas server-to-server:** [HmacValidator.java](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/security/HmacValidator.java) implementa `HMAC_SHA256(secret, "<timestamp>:<METHOD>:<path>:<sha256(body)>")` com:
    - Replay protection via timestamp + 5 min skew.
-   - Constant-time comparison via XOR loop ([HmacValidator.java:115-124](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/security/HmacValidator.java)).
+   - Constant-time comparison via XOR loop ([HmacValidator.java:115-124](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/security/HmacValidator.java)).
    - SHA-256 do body garante que tampering vira invalidação de assinatura.
-2. **Cobertura atual:** caller `N8N` pode optar por HMAC além do `X-API-Key`. Para Sprint 1 está implementado e testado ([HmacValidatorTest.java](../../../forward-api-java/src/test/java/)) mas não obrigatório em todos os endpoints — habilitação por endpoint fica para Sprint 2.
+2. **Cobertura atual:** caller `N8N` pode optar por HMAC além do `X-API-Key`. Para Sprint 1 está implementado e testado ([HmacValidatorTest.java](https://github.com/fwd-ford/forward-api-java/tree/main/src/test/java)) mas não obrigatório em todos os endpoints — habilitação por endpoint fica para Sprint 2.
 3. **Deserialização:** Jackson com configuração padrão Spring (rejeita tipos desconhecidos). Sem `enableDefaultTyping` (vetor de RCE via polymorphic deserialization).
-4. **CI/CD integrity:** `actions/checkout@v4`, `actions/setup-java@v4` pinados em versão fixa em [java-security.yml](../../../.github/.github/workflows/java-security.yml). Maven Wrapper pinado em 3.9.
+4. **CI/CD integrity:** `actions/checkout@v4`, `actions/setup-java@v4` pinados em versão fixa em [java-security.yml](https://github.com/fwd-ford/.github/blob/main/.github/workflows/java-security.yml). Maven Wrapper pinado em 3.9.
 5. **Build artifact:** Dockerfile multi-stage, image base Eclipse Temurin oficial.
 
 **Status:** ⚠️ Parcial. Bem implementado para Sprint 1, mas obrigatoriedade do HMAC em endpoints sensíveis fica como evolução. Equivale aos 5pts opcionais da rubrica (Seção 3 do critério oficial).
@@ -246,12 +246,12 @@ Em 2026-05-23 o profile Maven `security` (que rodava `dependency-check-maven 10.
 
 | Item | Implementação |
 | --- | --- |
-| Correlation ID | `X-Request-Id` UUID em [RequestIdFilter.java:27-33](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/web/RequestIdFilter.java); injetado em MDC e devolvido no response |
-| Logs estruturados | JSON em produção via Logstash encoder ([logback-spring.xml:7-11](../../../forward-api-java/src/main/resources/logback-spring.xml)); `service: forward-api` como campo fixo |
-| Audit trail | Tabela [audit_log](../../../forward-infra/supabase/migrations/009_create_audit_log.sql) append-only; campos: `actor_id`, `actor_role`, `action`, `resource_type`, `resource_id`, `ip_address`, `user_agent`, `request_id`, `payload`, `created_at` |
-| Append-only enforce | `REVOKE UPDATE, DELETE ON audit_log FROM PUBLIC` ([009_create_audit_log.sql:26](../../../forward-infra/supabase/migrations/009_create_audit_log.sql)) |
-| Anonimização auditada | Cada `anonymize_customer` insere linha em audit_log com `reason` e `at` ([013_lgpd_retention_policy.sql:46-53](../../../forward-infra/supabase/migrations/013_lgpd_retention_policy.sql)) |
-| Logs de erro não tratado | `log.error("unhandled error path={} msg={}", ...)` com stack interno ([GlobalExceptionHandler.java:66](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/error/GlobalExceptionHandler.java)) |
+| Correlation ID | `X-Request-Id` UUID em [RequestIdFilter.java:27-33](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/web/RequestIdFilter.java); injetado em MDC e devolvido no response |
+| Logs estruturados | JSON em produção via Logstash encoder ([logback-spring.xml:7-11](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/resources/logback-spring.xml)); `service: forward-api` como campo fixo |
+| Audit trail | Tabela [audit_log](https://github.com/fwd-ford/forward-infra/blob/main/supabase/migrations/009_create_audit_log.sql) append-only; campos: `actor_id`, `actor_role`, `action`, `resource_type`, `resource_id`, `ip_address`, `user_agent`, `request_id`, `payload`, `created_at` |
+| Append-only enforce | `REVOKE UPDATE, DELETE ON audit_log FROM PUBLIC` ([009_create_audit_log.sql:26](https://github.com/fwd-ford/forward-infra/blob/main/supabase/migrations/009_create_audit_log.sql)) |
+| Anonimização auditada | Cada `anonymize_customer` insere linha em audit_log com `reason` e `at` ([013_lgpd_retention_policy.sql:46-53](https://github.com/fwd-ford/forward-infra/blob/main/supabase/migrations/013_lgpd_retention_policy.sql)) |
+| Logs de erro não tratado | `log.error("unhandled error path={} msg={}", ...)` com stack interno ([GlobalExceptionHandler.java:66](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/error/GlobalExceptionHandler.java)) |
 | Health probe | `/health` e `/ready` para alerta de liveness pelo Fly.io |
 | Métricas Fly.io | Plataforma já agrega CPU, RAM, requests/s, error rate, latency p95/p99 |
 
@@ -270,7 +270,7 @@ Em 2026-05-23 o profile Maven `security` (que rodava `dependency-check-maven 10.
 ForwardService backend **não faz outbound HTTP para URLs vindas do cliente** em nenhum endpoint do Sprint 1.
 
 Outbounds que existem:
-- JWKS fetch para Supabase ([JwksJwtValidator](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/security/JwksJwtValidator.java)): URL configurada via env var `SUPABASE_JWKS_URL`, não controlada pelo cliente.
+- JWKS fetch para Supabase ([JwksJwtValidator](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/security/JwksJwtValidator.java)): URL configurada via env var `SUPABASE_JWKS_URL`, não controlada pelo cliente.
 - Postgres connection: URL configurada via env var `DATABASE_URL`, não controlada pelo cliente.
 
 Não há endpoint que aceite URL do cliente e faça fetch (ex: image proxy, webhook caller, OG preview, URL shortener).

--- a/academic/cyber/03_SECURITY_PLAN.md
+++ b/academic/cyber/03_SECURITY_PLAN.md
@@ -103,7 +103,7 @@ Itens marcados como **risco residual aceito** no [01_THREAT_MODEL.md §6](./01_T
 | Artigo / requisito | Implementação |
 | --- | --- |
 | Art. 5 — base legal e consentimento | Coluna `lgpd_consent_at` em `customers`; mobile precisa coletar (R11) |
-| Art. 16 — eliminação após término | Reaper `anonymize_expired_customers()` diário ([013](../../../forward-infra/supabase/migrations/013_lgpd_retention_policy.sql)) |
+| Art. 16 — eliminação após término | Reaper `anonymize_expired_customers()` diário ([013](https://github.com/fwd-ford/forward-infra/blob/main/supabase/migrations/013_lgpd_retention_policy.sql)) |
 | Art. 18 — direitos do titular (deletion request) | `lgpd_deletion_requested_at` + cooling-off 30d + `anonymize_customer()` |
 | Art. 37 — registro de operações | `audit_log` append-only com `actor_id`, `action`, `resource_*`, `created_at` |
 | Art. 46 — segurança (medidas técnicas) | TLS, HSTS, AES-256 em repouso, JWT assinado, rate limit, RLS |
@@ -119,23 +119,23 @@ Todos os controles abaixo são código ou configuração versionada — nada é 
 
 | Controle | Tipo | Arquivo |
 | --- | --- | --- |
-| Force HTTPS | Config | [fly.toml:18](../../../forward-api-java/fly.toml) |
-| Security headers | Filter | [SecurityHeadersFilter.java](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/web/SecurityHeadersFilter.java) |
-| CORS allowlist | Config + Bean | [CorsConfig.java](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/web/CorsConfig.java) + [fly.toml:11](../../../forward-api-java/fly.toml) |
-| Spring Security chain | Bean | [SecurityConfig.java](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/security/SecurityConfig.java) |
-| JWT validators (HS256, JWKS, Alg-aware) | Class | [security/](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/security/) |
-| Auth filter | Filter | [AuthFilter.java](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/security/AuthFilter.java) |
-| Rate limit | Filter | [RateLimitFilter.java](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/security/RateLimitFilter.java) |
-| HMAC validator | Class | [HmacValidator.java](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/security/HmacValidator.java) |
-| Input validation | Class | [Validations.java](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/web/Validations.java) |
-| Request ID | Filter | [RequestIdFilter.java](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/web/RequestIdFilter.java) |
-| Global exception handler | Advice | [GlobalExceptionHandler.java](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/error/GlobalExceptionHandler.java) |
-| RLS Postgres | Migration | [010_rls_policies.sql](../../../forward-infra/supabase/migrations/010_rls_policies.sql) |
-| Audit log | Migration | [009_create_audit_log.sql](../../../forward-infra/supabase/migrations/009_create_audit_log.sql) |
-| LGPD retention | Migration | [013_lgpd_retention_policy.sql](../../../forward-infra/supabase/migrations/013_lgpd_retention_policy.sql) |
-| JSON logs | Config | [logback-spring.xml](../../../forward-api-java/src/main/resources/logback-spring.xml) |
-| CI security scan | Workflow | [java-security.yml](../../../.github/.github/workflows/java-security.yml) |
-| Secret scan | Workflow | [secrets-scan.yml](../../../.github/.github/workflows/secrets-scan.yml) |
+| Force HTTPS | Config | [fly.toml:18](https://github.com/fwd-ford/forward-api-java/blob/main/fly.toml) |
+| Security headers | Filter | [SecurityHeadersFilter.java](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/web/SecurityHeadersFilter.java) |
+| CORS allowlist | Config + Bean | [CorsConfig.java](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/web/CorsConfig.java) + [fly.toml:11](https://github.com/fwd-ford/forward-api-java/blob/main/fly.toml) |
+| Spring Security chain | Bean | [SecurityConfig.java](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/security/SecurityConfig.java) |
+| JWT validators (HS256, JWKS, Alg-aware) | Class | [security/](https://github.com/fwd-ford/forward-api-java/tree/main/src/main/java/com/fwdford/forwardapi/security) |
+| Auth filter | Filter | [AuthFilter.java](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/security/AuthFilter.java) |
+| Rate limit | Filter | [RateLimitFilter.java](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/security/RateLimitFilter.java) |
+| HMAC validator | Class | [HmacValidator.java](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/security/HmacValidator.java) |
+| Input validation | Class | [Validations.java](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/web/Validations.java) |
+| Request ID | Filter | [RequestIdFilter.java](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/web/RequestIdFilter.java) |
+| Global exception handler | Advice | [GlobalExceptionHandler.java](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/error/GlobalExceptionHandler.java) |
+| RLS Postgres | Migration | [010_rls_policies.sql](https://github.com/fwd-ford/forward-infra/blob/main/supabase/migrations/010_rls_policies.sql) |
+| Audit log | Migration | [009_create_audit_log.sql](https://github.com/fwd-ford/forward-infra/blob/main/supabase/migrations/009_create_audit_log.sql) |
+| LGPD retention | Migration | [013_lgpd_retention_policy.sql](https://github.com/fwd-ford/forward-infra/blob/main/supabase/migrations/013_lgpd_retention_policy.sql) |
+| JSON logs | Config | [logback-spring.xml](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/resources/logback-spring.xml) |
+| CI security scan | Workflow | [java-security.yml](https://github.com/fwd-ford/.github/blob/main/.github/workflows/java-security.yml) |
+| Secret scan | Workflow | [secrets-scan.yml](https://github.com/fwd-ford/.github/blob/main/.github/workflows/secrets-scan.yml) |
 | Dependabot | Config | configurado por repo |
 
 ---
@@ -196,7 +196,7 @@ Ver [01_THREAT_MODEL.md §7](./01_THREAT_MODEL.md#7-procedimento-de-resposta-a-i
 | 1 | Threat model documentado | ✅ pronto | Cyber |
 | 2 | OWASP Top 10 mapeado | ✅ pronto | Cyber |
 | 3 | Plano de segurança (este doc) | ✅ pronto | Cyber |
-| 4 | Demonstrar HMAC funcional via teste | ✅ ([HmacValidatorTest](../../../forward-api-java/src/test/java/)) | já existente |
+| 4 | Demonstrar HMAC funcional via teste | ✅ ([HmacValidatorTest](https://github.com/fwd-ford/forward-api-java/tree/main/src/test/java)) | já existente |
 | 5 | Demonstrar reaper LGPD em execução local | ⚠️ rodar `SELECT anonymize_expired_customers();` em DB com fixture | Quem fizer demo |
 | 6 | Vídeo de pitch: incluir slide rápido sobre LGPD + RLS + audit_log | ⚠️ pendente | Quem grava pitch |
 

--- a/academic/soa/README.md
+++ b/academic/soa/README.md
@@ -1,0 +1,188 @@
+# SOA — Entrega Sprint 1
+
+![disciplina](https://img.shields.io/badge/disciplina-SOA-purple?style=flat-square)
+![prof](https://img.shields.io/badge/prof-Salatiel-blue?style=flat-square)
+![data](https://img.shields.io/badge/entrega-2026--05--24-brightgreen?style=flat-square)
+![combinado](https://img.shields.io/badge/diagramas-Mermaid_(combinado_c%2F_Salatiel)-orange?style=flat-square)
+
+> Pacote da disciplina **SOA (Service-Oriented Architecture)** do Desafio 02 Ford-FIAP 2026.
+> Entrega via **Mermaid no markdown** em vez de ferramenta gráfica externa, conforme combinado com o Prof. Salatiel.
+
+---
+
+## 1. O que está sendo entregue
+
+| Item | Onde está | Por quê |
+| --- | --- | --- |
+| **Arquitetura de serviços (diagramas)** | `forward-docs/project/03_SOLUTION_DESIGN.md` — 5 blocos Mermaid | Visão geral, elenco, fluxos, modelo de dados |
+| **REST API (Spring Boot)** | `forward-api-java/src/main/java/com/fwdford/forwardapi/web/` — 8 endpoints | Camada síncrona de aplicação |
+| **SOAP API (Spring WS)** | `forward-api-java/src/main/java/com/fwdford/forwardapi/soap/` — 1 operação contract-first | Interoperabilidade legacy / requisito SOA |
+| **OpenAPI / Swagger** | `springdoc-openapi 2.7.0` em runtime: `/swagger-ui.html` + `/v3/api-docs` | Contrato auto-documentado |
+| **Migrations versionadas** | `forward-infra/supabase/migrations/` — 13 arquivos SQL numerados | Persistência rastreável |
+| **Deploy contínuo** | Fly.io (`forward-api-java`) + Supabase (Postgres) | API live, acessível pelo mobile e pelo Swagger |
+
+---
+
+## 2. Catálogo de endpoints REST
+
+Base path: `/api/v1`. Autenticação: `Authorization: Bearer <JWT>` (HS256+JWKS) ou `X-API-Key`.
+
+| Verbo | Path | Controller | Função |
+| --- | --- | --- | --- |
+| `GET` | `/health` | [HealthController.java:32](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/web/HealthController.java#L32) | Liveness probe (Fly.io / Kubernetes) |
+| `GET` | `/ready` | [HealthController.java:48](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/web/HealthController.java#L48) | Readiness probe (DB + dependências) |
+| `GET` | `/api/v1/me` | [MeController.java:24](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/web/MeController.java#L24) | Quem é o caller (claims do JWT) |
+| `GET` | `/api/v1/customers/{id}` | [CustomerController.java:33](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/web/CustomerController.java#L33) | Detalhe de cliente (RBAC dealer/analyst/admin) |
+| `GET` | `/api/v1/vehicles/{vin}` | [VehicleController.java:32](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/web/VehicleController.java#L32) | Detalhe de veículo por VIN |
+| `GET` | `/api/v1/leads` | [LeadController.java:38](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/web/LeadController.java#L38) | Lista de leads do atendente (paginada + filtros) |
+| `GET` | `/api/v1/scores/{customerId}` | [ScoreController.java:33](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/web/ScoreController.java#L33) | Churn score atual de um cliente |
+| `POST` | `/api/v1/service-events` | [ServiceEventController.java:40](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/web/ServiceEventController.java#L40) | Registra evento de serviço (contato, agendamento, fechamento) |
+
+Cada controller usa `@Operation` do springdoc, então o Swagger renderiza descrição, parâmetros e exemplos em runtime sem trabalho manual.
+
+---
+
+## 3. Catálogo SOAP
+
+Spring WS contract-first em `urn:forwardservice:vehicles`.
+
+| Item | Valor |
+| --- | --- |
+| **Endpoint** | `POST /soap/*` (servlet `MessageDispatcherServlet`) |
+| **WSDL público** | `GET /soap/vehicles.wsdl` (gerado dinamicamente) |
+| **Schema XSD** | [forward-api-java/src/main/resources/xsd/vehicles.xsd](../../../forward-api-java/src/main/resources/xsd/vehicles.xsd) |
+| **Operação** | `GetVehicleRequest → GetVehicleResponse` |
+| **Bootstrap** | [WebServiceConfig.java](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/soap/WebServiceConfig.java) |
+| **Handler** | [VehicleEndpoint.java](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/soap/VehicleEndpoint.java) |
+
+Schema (fonte da verdade):
+
+```xml
+<xs:element name="GetVehicleRequest">
+  <xs:complexType><xs:sequence>
+    <xs:element name="VIN" type="xs:string"/>
+  </xs:sequence></xs:complexType>
+</xs:element>
+
+<xs:element name="GetVehicleResponse">
+  <xs:complexType><xs:sequence>
+    <xs:element name="VIN"          type="xs:string"/>
+    <xs:element name="Model"        type="xs:string"/>
+    <xs:element name="Year"         type="xs:int"/>
+    <xs:element name="Discontinued" type="xs:boolean"/>
+  </xs:sequence></xs:complexType>
+</xs:element>
+```
+
+**Por que SOAP além de REST?** O critério SOA exige interoperabilidade entre serviços com contrato forte. REST cobre o cliente moderno (mobile, web). SOAP cobre o cenário "concessionária com ERP legacy que só fala WSDL" — exatamente o público real da Ford.
+
+---
+
+## 4. Diagramas (Mermaid)
+
+Os 5 diagramas Mermaid vivem no [03_SOLUTION_DESIGN.md](../../project/03_SOLUTION_DESIGN.md). Combinado com o Prof. Salatiel: Mermaid renderiza nativo no GitHub, o que substitui Archi sem perder rastreabilidade.
+
+| # | Linha | Tipo | Sobre o quê |
+| --- | --- | --- | --- |
+| 1 | [75](../../project/03_SOLUTION_DESIGN.md#L75) | `flowchart` | Visão geral — cenário e tese em uma página |
+| 2 | [152](../../project/03_SOLUTION_DESIGN.md#L152) | `flowchart` | Elenco e interligação entre as 7 plataformas |
+| 3 | [595](../../project/03_SOLUTION_DESIGN.md#L595) | `gantt`/`timeline` | Cronograma original v2.0 (referência histórica) |
+| 4 | [658](../../project/03_SOLUTION_DESIGN.md#L658) | `erDiagram` | Modelo de dados completo (tabelas + FKs) |
+| 5 | [789](../../project/03_SOLUTION_DESIGN.md#L789) | `flowchart` | Pipeline `vin_features` (derivação do dataset oficial) |
+
+Padrão Mermaid usado: **labels curtas, sem emojis, sem `&` em strings** (quebra o parser).
+
+---
+
+## 5. Persistência e migrations
+
+13 migrations versionadas em [forward-infra/supabase/migrations/](../../../forward-infra/supabase/migrations/):
+
+```
+001_create_dealers.sql              008_create_lead_outcomes.sql
+002_create_customers.sql            009_create_audit_log.sql
+003_create_vehicles.sql             010_rls_policies.sql
+004_create_service_orders.sql       011_triggers_updated_at.sql
+005_create_churn_scores.sql         012_add_service_event_fields.sql
+006_create_leads.sql                013_lgpd_retention_policy.sql
+007_create_communications.sql
+```
+
+Aplicadas via Supabase MCP em prod (projeto `ysewoopjgdpvnkfhffgy`, região SP). Cada migration é idempotente e revisada por `get_advisors` (security + performance lints).
+
+---
+
+## 6. Princípios SOA evidenciados
+
+| Princípio (Erl, *SOA Principles of Service Design*) | Como está aplicado |
+| --- | --- |
+| **Standardized Service Contract** | Swagger gerado de annotations + WSDL gerado de XSD. Contrato é a fonte da verdade, não o código. |
+| **Service Loose Coupling** | Mobile não conhece nada do ML. Backend serve score já calculado. ML escreve em tabela própria. |
+| **Service Abstraction** | SOAP esconde a implementação Java por trás do envelope. REST esconde Postgres por trás dos DTOs. |
+| **Service Reusability** | `VehicleService` é consumido pelo `VehicleController` (REST) **e** pelo `VehicleEndpoint` (SOAP). Mesma lógica, dois transportes. |
+| **Service Autonomy** | Cada controller falha de forma isolada (RFC 7807 com `requestId`, sem leak entre serviços). |
+| **Service Statelessness** | JWT carrega claims (`sub`, `role`, `dealerId`). Servidor não guarda sessão. |
+| **Service Discoverability** | `/swagger-ui.html` + `/soap/vehicles.wsdl` ambos públicos, sem auth, prontos para discovery. |
+| **Service Composability** | `POST /service-events` aciona n8n (WhatsApp), que pode acionar `GET /scores/{id}` em fluxo orquestrado. |
+
+---
+
+## 7. Como testar (Prof. Salatiel)
+
+### REST via Swagger
+```bash
+# API em prod (Fly.io)
+open https://forward-api-java.fly.dev/swagger-ui.html
+
+# Local
+cd forward-repos/forward-api-java && bash mvnw spring-boot:run
+open http://localhost:8080/swagger-ui.html
+```
+
+### SOAP via WSDL
+```bash
+curl https://forward-api-java.fly.dev/soap/vehicles.wsdl
+
+# Chamada de exemplo
+curl -X POST https://forward-api-java.fly.dev/soap/vehicles \
+  -H "Content-Type: text/xml" \
+  -H "SOAPAction: " \
+  --data '<?xml version="1.0"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+               xmlns:v="urn:forwardservice:vehicles">
+  <soap:Body>
+    <v:GetVehicleRequest><v:VIN>1FTFW1ET5DFC10312</v:VIN></v:GetVehicleRequest>
+  </soap:Body>
+</soap:Envelope>'
+```
+
+### Mobile consumindo a API
+App em Expo Go, credencial de teste `teste@gmail.com` / `teste123` (ver [forward-mobile/README.md](../../../forward-mobile/README.md)). Os 8 endpoints REST estão sendo chamados no fluxo Home → Leads → Lead Detail.
+
+---
+
+## 8. Checklist de cobertura
+
+| Item | Estado |
+| --- | --- |
+| REST com no mínimo 3 endpoints distintos | 8/3 — sobrou |
+| SOAP com no mínimo 1 operação contract-first | 1/1 |
+| Documentação automática do contrato | Swagger (OpenAPI 3) + WSDL dinâmico |
+| Persistência versionada (migrations) | 13 arquivos SQL numerados |
+| Diagrama de arquitetura | 5 Mermaid em `03_SOLUTION_DESIGN.md` |
+| Deploy live para demonstração | Fly.io (`forward-api-java.fly.dev`) |
+| Princípios SOA documentados | 8/8 (Erl) na §6 |
+| Segurança no transporte | JWT HS256+JWKS, RBAC, HMAC opcional — ver [academic/cyber/](../cyber/) |
+
+---
+
+## Apêndice — Onde olhar primeiro
+
+| Quero ver... | Vou pra... |
+| --- | --- |
+| Os diagramas | [project/03_SOLUTION_DESIGN.md §1, §2, §8](../../project/03_SOLUTION_DESIGN.md) |
+| Os controllers REST | [forward-api-java/src/main/java/com/fwdford/forwardapi/web/](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/web/) |
+| O contrato SOAP | [forward-api-java/src/main/resources/xsd/vehicles.xsd](../../../forward-api-java/src/main/resources/xsd/vehicles.xsd) |
+| As migrations | [forward-infra/supabase/migrations/](../../../forward-infra/supabase/migrations/) |
+| O backend rodando | `https://forward-api-java.fly.dev/swagger-ui.html` |
+| Como o mobile consome | [forward-mobile/lib/api.ts](../../../forward-mobile/lib/api.ts) |

--- a/academic/soa/README.md
+++ b/academic/soa/README.md
@@ -29,14 +29,14 @@ Base path: `/api/v1`. Autenticação: `Authorization: Bearer <JWT>` (HS256+JWKS)
 
 | Verbo | Path | Controller | Função |
 | --- | --- | --- | --- |
-| `GET` | `/health` | [HealthController.java:32](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/web/HealthController.java#L32) | Liveness probe (Fly.io / Kubernetes) |
-| `GET` | `/ready` | [HealthController.java:48](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/web/HealthController.java#L48) | Readiness probe (DB + dependências) |
-| `GET` | `/api/v1/me` | [MeController.java:24](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/web/MeController.java#L24) | Quem é o caller (claims do JWT) |
-| `GET` | `/api/v1/customers/{id}` | [CustomerController.java:33](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/web/CustomerController.java#L33) | Detalhe de cliente (RBAC dealer/analyst/admin) |
-| `GET` | `/api/v1/vehicles/{vin}` | [VehicleController.java:32](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/web/VehicleController.java#L32) | Detalhe de veículo por VIN |
-| `GET` | `/api/v1/leads` | [LeadController.java:38](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/web/LeadController.java#L38) | Lista de leads do atendente (paginada + filtros) |
-| `GET` | `/api/v1/scores/{customerId}` | [ScoreController.java:33](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/web/ScoreController.java#L33) | Churn score atual de um cliente |
-| `POST` | `/api/v1/service-events` | [ServiceEventController.java:40](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/web/ServiceEventController.java#L40) | Registra evento de serviço (contato, agendamento, fechamento) |
+| `GET` | `/health` | [HealthController.java:32](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/web/HealthController.java#L32) | Liveness probe (Fly.io / Kubernetes) |
+| `GET` | `/ready` | [HealthController.java:48](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/web/HealthController.java#L48) | Readiness probe (DB + dependências) |
+| `GET` | `/api/v1/me` | [MeController.java:24](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/web/MeController.java#L24) | Quem é o caller (claims do JWT) |
+| `GET` | `/api/v1/customers/{id}` | [CustomerController.java:33](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/web/CustomerController.java#L33) | Detalhe de cliente (RBAC dealer/analyst/admin) |
+| `GET` | `/api/v1/vehicles/{vin}` | [VehicleController.java:32](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/web/VehicleController.java#L32) | Detalhe de veículo por VIN |
+| `GET` | `/api/v1/leads` | [LeadController.java:38](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/web/LeadController.java#L38) | Lista de leads do atendente (paginada + filtros) |
+| `GET` | `/api/v1/scores/{customerId}` | [ScoreController.java:33](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/web/ScoreController.java#L33) | Churn score atual de um cliente |
+| `POST` | `/api/v1/service-events` | [ServiceEventController.java:40](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/web/ServiceEventController.java#L40) | Registra evento de serviço (contato, agendamento, fechamento) |
 
 Cada controller usa `@Operation` do springdoc, então o Swagger renderiza descrição, parâmetros e exemplos em runtime sem trabalho manual.
 
@@ -50,10 +50,10 @@ Spring WS contract-first em `urn:forwardservice:vehicles`.
 | --- | --- |
 | **Endpoint** | `POST /soap/*` (servlet `MessageDispatcherServlet`) |
 | **WSDL público** | `GET /soap/vehicles.wsdl` (gerado dinamicamente) |
-| **Schema XSD** | [forward-api-java/src/main/resources/xsd/vehicles.xsd](../../../forward-api-java/src/main/resources/xsd/vehicles.xsd) |
+| **Schema XSD** | [forward-api-java · vehicles.xsd](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/resources/xsd/vehicles.xsd) |
 | **Operação** | `GetVehicleRequest → GetVehicleResponse` |
-| **Bootstrap** | [WebServiceConfig.java](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/soap/WebServiceConfig.java) |
-| **Handler** | [VehicleEndpoint.java](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/soap/VehicleEndpoint.java) |
+| **Bootstrap** | [WebServiceConfig.java](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/soap/WebServiceConfig.java) |
+| **Handler** | [VehicleEndpoint.java](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/java/com/fwdford/forwardapi/soap/VehicleEndpoint.java) |
 
 Schema (fonte da verdade):
 
@@ -96,7 +96,7 @@ Padrão Mermaid usado: **labels curtas, sem emojis, sem `&` em strings** (quebra
 
 ## 5. Persistência e migrations
 
-13 migrations versionadas em [forward-infra/supabase/migrations/](../../../forward-infra/supabase/migrations/):
+13 migrations versionadas em [forward-infra · supabase/migrations/](https://github.com/fwd-ford/forward-infra/tree/main/supabase/migrations):
 
 ```
 001_create_dealers.sql              008_create_lead_outcomes.sql
@@ -157,7 +157,7 @@ curl -X POST https://forward-api-java.fly.dev/soap/vehicles \
 ```
 
 ### Mobile consumindo a API
-App em Expo Go, credencial de teste `teste@gmail.com` / `teste123` (ver [forward-mobile/README.md](../../../forward-mobile/README.md)). Os 8 endpoints REST estão sendo chamados no fluxo Home → Leads → Lead Detail.
+App em Expo Go, credencial de teste `teste@gmail.com` / `teste123` (ver [forward-mobile · README.md](https://github.com/fwd-ford/forward-mobile/blob/main/README.md)). Os 8 endpoints REST estão sendo chamados no fluxo Home → Leads → Lead Detail.
 
 ---
 
@@ -181,8 +181,8 @@ App em Expo Go, credencial de teste `teste@gmail.com` / `teste123` (ver [forward
 | Quero ver... | Vou pra... |
 | --- | --- |
 | Os diagramas | [project/03_SOLUTION_DESIGN.md §1, §2, §8](../../project/03_SOLUTION_DESIGN.md) |
-| Os controllers REST | [forward-api-java/src/main/java/com/fwdford/forwardapi/web/](../../../forward-api-java/src/main/java/com/fwdford/forwardapi/web/) |
-| O contrato SOAP | [forward-api-java/src/main/resources/xsd/vehicles.xsd](../../../forward-api-java/src/main/resources/xsd/vehicles.xsd) |
-| As migrations | [forward-infra/supabase/migrations/](../../../forward-infra/supabase/migrations/) |
+| Os controllers REST | [forward-api-java · web/](https://github.com/fwd-ford/forward-api-java/tree/main/src/main/java/com/fwdford/forwardapi/web) |
+| O contrato SOAP | [forward-api-java · vehicles.xsd](https://github.com/fwd-ford/forward-api-java/blob/main/src/main/resources/xsd/vehicles.xsd) |
+| As migrations | [forward-infra · supabase/migrations/](https://github.com/fwd-ford/forward-infra/tree/main/supabase/migrations) |
 | O backend rodando | `https://forward-api-java.fly.dev/swagger-ui.html` |
-| Como o mobile consome | [forward-mobile/lib/api.ts](../../../forward-mobile/lib/api.ts) |
+| Como o mobile consome | [forward-mobile · lib/api.ts](https://github.com/fwd-ford/forward-mobile/blob/main/lib/api.ts) |

--- a/project/02c_RESULTADOS_PESQUISA_II_CRITICAS.md
+++ b/project/02c_RESULTADOS_PESQUISA_II_CRITICAS.md
@@ -57,7 +57,7 @@ ID — Título
 
 - **Pergunta:** Quantas colunas, dtypes, missing %, cardinalidade?
 - **Resposta:** **500.000 linhas × 37 colunas**. 22 numéricas (`float64`), 8 inteiras (`int64`), 7 categóricas (`object`). **14 colunas têm missing**, todas entre 0,60% e 2,47% — maior é `renda_mensal` (2,47%) e `score_credito` (2,04%). **Cardinalidade-chave:** `cliente_id` 500k unique (PK), `valor_veiculo` 477k (quase contínua), `modelo_veiculo` 14, `categoria_veiculo` 5, `regiao` 3, `perfil_latente` 4 (target de segmentação), `churn_rede_24m` 2 (target binário).
-- **Fonte:** Análise direta — [tmp_research/bloco_a_dataset.py](../../tmp_research/bloco_a_dataset.py), 06/05/2026
+- **Fonte:** Análise direta — `tmp_research/bloco_a_dataset.py` (script local do lider), 06/05/2026
 - **Hipótese:** ✅ Validada — dataset é tratável sem ETL pesado; missing é tudo MAR (Missing At Random) provável.
 - **Impacto:** Imputação por mediana é suficiente pro Sprint 1 (sem MICE/iterativo). Schema documentado vai pra DOC 07 anexo.
 

--- a/project/02d_RESULTADOS_PESQUISA_II_CRITICAS_PARTE2.md
+++ b/project/02d_RESULTADOS_PESQUISA_II_CRITICAS_PARTE2.md
@@ -170,7 +170,7 @@ Das 14 hipóteses críticas: **10 validadas**, **2 parcialmente validadas**, **2
   | DecisionTree | 0,8420 | **0,4964** | 0,2429 | **0,0474** | 0,6923 |
 
   **DIAGNÓSTICO CHURN:** Todos os modelos atingem ~85% accuracy **só batendo na classe majoritária** (recall positivo praticamente zero). ROC-AUC ~0,73 indica que **o sinal existe**, mas threshold default 0,5 está errado. Sem `class_weight='balanced'` ou SMOTE, o modelo é clinicamente inútil.
-- **Fonte:** Análise direta — [tmp_research/bloco_b_ml04_classifiers.py](../../tmp_research/bloco_b_ml04_classifiers.py), 06/05/2026
+- **Fonte:** Análise direta — `tmp_research/bloco_b_ml04_classifiers.py` (script local do lider), 06/05/2026
 - **Hipótese:** ⚠️ Parcial — perfil totalmente validado (LogReg vence); churn precisa segundo round com cost-sensitive antes de entrar em produção.
 - **Impacto:**
   - **Modelo final do segmentador (Sprint 1):** **LogReg com 24 features pré-compra** (rápido, interpretável, F1=0,86, sem ganho de GB que custa 80x mais fit).
@@ -316,7 +316,7 @@ Das 14 hipóteses críticas: **10 validadas**, **2 parcialmente validadas**, **2
 - **Fonte:** [Label Your Data — Synthetic vs Real (2026)](https://labelyourdata.com/articles/synthetic-data-vs-real-data); [YData — Validating Synthetic Predictive Performance](https://ydata.ai/resources/how-to-validate-the-predictive-performance-of-synthetic-data.html); [Qualtrics — Synthetic Data Validation](https://www.qualtrics.com/articles/strategy-research/synthetic-data-validation/); [arXiv:2302.04062 — ML for Synthetic Data Generation](https://arxiv.org/html/2302.04062v9)
 - **Hipótese:** ✅ Validada — protocolo claro de quando confiar e quando duvidar.
 - **Impacto:**
-  - **Posicionamento honesto no DOC 07 e no pitch:** "achados do Bloco A (DS01–DS10) são prova de método sobre dataset sintético de aquecimento. Quando o real chegar, rerodaremos `tmp_research/bloco_a_dataset.py` e aplicaremos teste TSTR vs TRTR — se F1 pós-real ≥ 0,95 × F1 atual (0,86 × 0,95 = **0,817**), modelo é aceito; senão, refit do zero."
+  - **Posicionamento honesto no DOC 07 e no pitch:** "achados do Bloco A (DS01-DS10) são prova de método sobre dataset sintético de aquecimento. Quando o real chegar, rerodaremos o script `tmp_research/bloco_a_dataset.py` (workspace local) e aplicaremos teste TSTR vs TRTR — se F1 pós-real >= 0,95 × F1 atual (0,86 × 0,95 = **0,817**), modelo é aceito; senão, refit do zero."
   - **Plano B no DOC 04:** se dataset real chegar tarde demais pro Sprint 1, manter sintético com asterisco e prometer iteração no Sprint 2.
   - **Estratégia de mistura:** quando real chegar com volume baixo, treinar híbrido (sintético + real, sample weights ponderando real mais).
 

--- a/project/02d_RESULTADOS_PESQUISA_II_CRITICAS_PARTE2.md
+++ b/project/02d_RESULTADOS_PESQUISA_II_CRITICAS_PARTE2.md
@@ -379,7 +379,7 @@ Das 14 hipóteses críticas: **10 validadas**, **2 parcialmente validadas**, **2
 6. **Bloco I → DOC 04 + Performance Console:** VIN Share como hero metric; % migração entre perfis como leading.
 7. **Bloco J → mentalidade do time:** comunicar com o grupo (Salatiel + 2 outros) que disciplinas pesam no mesmo bloco — alinhamento de prioridade e zero retrabalho disciplinar.
 
-**Pesquisas 🟡 importantes** (~25 itens) e 🟢 enriquecimento (~16 itens) seguem catalogadas em [project_research_map_v2.md](../../../C--Users-jotin--claude-projects-c--Users-jotin-Documents-Ford/memory/project_research_map_v2.md) para execução conforme prioridade durante a Sprint.
+**Pesquisas 🟡 importantes** (~25 itens) e 🟢 enriquecimento (~16 itens) seguem catalogadas no mapa de pesquisa v2 (memory local do lider) para execução conforme prioridade durante a Sprint.
 
 ---
 


### PR DESCRIPTION
## Resumo

Cria \`academic/soa/README.md\` como ponto de entrada da disciplina SOA para o Prof. Salatiel. Substitui a falta de pasta dedicada (Cyber, ML, Testing, Pitch e Video ja tinham; SOA nao).

Combinado com o prof: **diagramas via Mermaid** em vez de Archi (rastreavel direto no GitHub, sem export manual).

## O que entra na entrega

- **8 endpoints REST** documentados (Health, Me, Customer, Vehicle, Lead, Score, ServiceEvent) com link direto pro controller no \`forward-api-java\`
- **1 operacao SOAP contract-first** (\`GetVehicle\` em \`urn:forwardservice:vehicles\`) com WSDL dinamico em \`/soap/vehicles.wsdl\`
- **5 diagramas Mermaid** ja existentes em \`project/03_SOLUTION_DESIGN.md\` (visao geral, elenco, cronograma, modelo de dados, vin_features)
- **13 migrations SQL** versionadas em \`forward-infra/supabase/migrations/\` (aplicadas em prod, projeto \`ysewoopjgdpvnkfhffgy\`)
- **Swagger live** em \`https://forward-api-java.fly.dev/swagger-ui.html\`
- **8 principios SOA (Erl)** mapeados ao codigo na secao 6

## Cobertura vs criterio SOA

| Item | Status |
| --- | --- |
| REST com 3+ endpoints | 8/3 |
| SOAP contract-first | 1/1 |
| Documentacao automatica (Swagger + WSDL) | OK |
| Persistencia versionada | 13 migrations |
| Diagrama de arquitetura | 5 Mermaid |
| Deploy live para demo | Fly.io |

## Test plan

- [ ] Abrir \`academic/soa/README.md\` no GitHub e validar que todos os links navegam (controllers, XSD, migrations, Mermaid)
- [ ] Confirmar que \`https://forward-api-java.fly.dev/swagger-ui.html\` renderiza 8 endpoints
- [ ] Confirmar que \`https://forward-api-java.fly.dev/soap/vehicles.wsdl\` retorna XML valido
- [ ] Salatiel consegue ler o README sem precisar abrir outros docs

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>